### PR TITLE
Fix input for getting choices

### DIFF
--- a/kniopass/cli.py
+++ b/kniopass/cli.py
@@ -39,6 +39,7 @@ yellow = functools.partial(color, colorama.Fore.YELLOW)
 def get_choice(prompt, choices, default=None):
     while True:
         print('{} [{}]: '.format(prompt, '/'.join(choices)), end='', flush=True)
+
         if msvcrt:
             c = msvcrt.getch().decode('utf-8')
             print()
@@ -47,13 +48,16 @@ def get_choice(prompt, choices, default=None):
             tty.setraw(sys.stdin)
             c = sys.stdin.read(1)[0]
             termios.tcsetattr(sys.stdin, termios.TCSADRAIN, orig_settings)
+
         if c in choices:
             return c
+
         if default is not None:
             return default
 
 
-class ExitException(Exception): pass
+class ExitException(Exception):
+    pass
 
 
 class KnioPassCLI(KnioPass):

--- a/kniopass/cli.py
+++ b/kniopass/cli.py
@@ -45,7 +45,11 @@ def get_choice(prompt, choices, default=None):
         else:
             orig_settings = termios.tcgetattr(sys.stdin)
             tty.setraw(sys.stdin)
-            c = chr(sys.stdin.read(1)[0])
+            c  = sys.stdin.read(1)[0]
+
+            if type(c) is int:
+                c = chr(c)
+
             termios.tcsetattr(sys.stdin, termios.TCSADRAIN, orig_settings)
         if c in choices:
             return c
@@ -58,6 +62,7 @@ class ExitException(Exception): pass
 
 class KnioPassCLI(KnioPass):
     DEFAULT_FIELDS = ('url', 'username', 'email')
+
     @classmethod
     def password_picker(cls):
         sets = [

--- a/kniopass/cli.py
+++ b/kniopass/cli.py
@@ -45,11 +45,7 @@ def get_choice(prompt, choices, default=None):
         else:
             orig_settings = termios.tcgetattr(sys.stdin)
             tty.setraw(sys.stdin)
-            c  = sys.stdin.read(1)[0]
-
-            if type(c) is int:
-                c = chr(c)
-
+            c = sys.stdin.read(1)[0]
             termios.tcsetattr(sys.stdin, termios.TCSADRAIN, orig_settings)
         if c in choices:
             return c
@@ -88,7 +84,7 @@ class KnioPassCLI(KnioPass):
                 return ''
 
         help_text = (
-            '[y] accept password             Toggle options:\n'
+            '\n[y] accept password             Toggle options:\n'
             '[enter] regenerate              [a] start with letter\n'
             '[m] manually enter password     [l] lowercase letters\n'
             '[+] longer                      [u] uppercase letters\n'

--- a/kniopass/kniopass.py
+++ b/kniopass/kniopass.py
@@ -58,4 +58,3 @@ class KnioPass(EncryptedFile):
                 continue
             return ''.join(password)
         raise Exception('Impossible requirements')
-


### PR DESCRIPTION
@Knio got this error while generating pw

```
File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 193, in _run_module_as_main 
  "__main__", mod_spec)
File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 85, in _run_code 
  exec(code, run_globals)
File "~/code/bradj/kniopass/kniopass/__main__.py", line 3, in <module> 
  main()
File "~/code/bradj/kniopass/kniopass/__init__.py", line 41, in main 
  pw = KnioPassCLI.password_picker()
File "~/code/bradj/kniopass/kniopass/cli.py", line 99, in password_picker
  command = get_choice('Accept password?', 'ym+-aludbeh', default='').lower()
File "~/code/bradj/kniopass/kniopass/cli.py", line 48, in get_choice
  c = chr(sys.stdin.read(1)[0])

TypeError: an integer is required (got type str)
```

I am on Mac OS using iTerm.